### PR TITLE
Structured Page-wise Output for Document Conversion

### DIFF
--- a/doctomarkdown/base.py
+++ b/doctomarkdown/base.py
@@ -1,6 +1,15 @@
 from abc import ABC, abstractmethod
-from typing import Optional, Dict, Any, Union
+from typing import Optional, Dict, Any, Union, List
 import os
+
+class PageResult:
+    def __init__(self, page_number: int, page_content: str):
+        self.page_number = page_number
+        self.page_content = page_content
+
+class ConversionResult:
+    def __init__(self, pages: List[PageResult]):
+        self.pages = pages
 
 class BaseConverter(ABC):
     def __init__(
@@ -35,8 +44,10 @@ class BaseConverter(ABC):
             f.write(content)
         return output_file
     
-    def convert(self) -> str:
-        """Main Entry point for conversion"""
-        markdown = self.extract_content()
-        return self.save_markdown(markdown)
+    def convert(self):
+        pages = self.extract_content()  # List[PageResult]
+        # Save markdown only if output_path is provided
+        if self.output_path:
+            self.save_markdown(self._markdown)
+        return ConversionResult(pages)
 

--- a/doctomarkdown/converters/pdf_to_markdown.py
+++ b/doctomarkdown/converters/pdf_to_markdown.py
@@ -1,25 +1,30 @@
-from doctomarkdown.base import BaseConverter
+from doctomarkdown.base import BaseConverter, PageResult, ConversionResult
 from typing import Optional
 import fitz #PyMuPDF
 
 
 class PdfToMarkdown(BaseConverter):
-    def extract_content(self) -> str:
+    def extract_content(self):
         doc = fitz.open(self.filepath)
+        pages = []
         markdown_lines = []
 
         for page_number, page in enumerate(doc, 1):
             text = page.get_text("text")
-            markdown_lines.append(f"## Page {page_number}\n\n{text.strip()}\n")
+            page_content = text.strip()
+            pages.append(PageResult(page_number, page_content))
+            markdown_lines.append(f"## Page {page_number}\n\n{page_content}\n")
 
             if self.extract_images:
                 images = page.get_images(full=True)
                 for img_index, img in enumerate(images):
                     xref = img[0]
                     pix = fitz.Pixmap(doc, xref)
-                    if pix.n < 5: #If this is GRAY or RGB
-                        pix.save(f"{self.output_path}/page{page_number}_img{img_index}.png")
-                        markdown_lines.append(f"![Image] (page{page_number}_img{img_index}.png)")
+                    if pix.n < 5:
+                        img_path = f"{self.output_path}/page{page_number}_img{img_index}.png"
+                        pix.save(img_path)
+                        markdown_lines.append(f"![Image]({img_path})")
                     pix = None
-                
-        return "\n".join(markdown_lines)
+
+        self._markdown = "\n".join(markdown_lines)
+        return pages

--- a/examples/pdf_example.py
+++ b/examples/pdf_example.py
@@ -1,11 +1,12 @@
 from doctomarkdown.factory import convert_to_markdown
 
-output_path = convert_to_markdown(
+result = convert_to_markdown(
     filepath="examples/sample_docs/sample.pdf",
     use_llm=False,
-    extract_images=False,
-    extract_tables=False,
-    output_path = "markdown_output"
+    extract_images=True,
+    extract_tables=True,
+    output_path="markdown_output"
 )
 
-print(f"Markdown saved at: {output_path}")
+for page in result.pages:
+    print(f"Page Number: {page.page_number} | Page Content: {page.page_content}")


### PR DESCRIPTION
**### Summary**
This PR refactors the document conversion workflow to provide a structured, page-wise output instead of a single Markdown string. The new output format enables users to access each page’s content individually, supporting more flexible downstream processing and improved usability.

Key Changes
Introduced **PageResult** and **ConversionResult** classes to encapsulate page-wise results.
Refactored PdfToMarkdown.extract_content to return a list of PageResult objects, each containing 

```
from doctomarkdown.factory import convert_to_markdown

result = convert_to_markdown(
    filepath="examples/sample_docs/sample.pdf",
    use_llm=False,
    extract_images=True,
    extract_tables=True,
    output_path="markdown_output"
)

for page in result.pages:
    print(f"Page Number: {page.page_number} | Page Content: {page.page_content}")```

